### PR TITLE
Add alerting support with BH/NBH channels

### DIFF
--- a/modules/apm/README.md
+++ b/modules/apm/README.md
@@ -27,14 +27,26 @@ resource "newrelic_alert_channel" "pagerduty_nbh" {
   }
 }
 
-module "newrelic_alerts" {
+module "newrelic_alerts_webfront_bh" {
   source      = "github.com/claranet/terraform-newrelic-alerts//modules/apm"
   environment = "production"
-  policy_name = "APM anomalies detected"
+  policy_name = "APM anomalies detected (BH)"
 
-  bh_alert_channel_ids               = [newrelic_alert_channel.pagerduty_bh.id]
-  nbh_alert_channel_ids              = [newrelic_alert_channel.pagerduty_nbh.id]
-  app_apdex_score_nbh_alerts_enabled = true
+  alert_channel_ids = [newrelic_alert_channel.pagerduty_bh.id]
+
+  app_apdex_score_threshold_duration_critical = 300
+  app_apdex_score_threshold_critical          = 0.85
+}
+
+module "newrelic_alerts_webfront_nbh" {
+  source      = "github.com/claranet/terraform-newrelic-alerts//modules/apm"
+  environment = "production"
+  policy_name = "APM anomalies detected (NBH)"
+
+  alert_channel_ids = [newrelic_alert_channel.pagerduty_nbh.id]
+
+  app_apdex_score_threshold_duration_critical = 600
+  app_apdex_score_threshold_critical          = 0.7
 }
 ```
 
@@ -49,11 +61,11 @@ module "newrelic_alerts" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| alert\_channel\_ids | Alert channels IDs | `list` | `[]` | no |
 | app\_apdex\_score\_aggregation\_window | APP Apdex Score aggregation window | `number` | `60` | no |
 | app\_apdex\_score\_enabled | Flag to enable APP Apdex Score alert condition | `bool` | `true` | no |
 | app\_apdex\_score\_evaluation\_offset | APP Apdex Score evaluation offset | `number` | `3` | no |
 | app\_apdex\_score\_message | Custom message for the APP Apdex Score alert condition | `string` | `"Apdex is low"` | no |
-| app\_apdex\_score\_nbh\_alerts\_enabled | Flag to enable APP Apdex Score critals alerts on NBH channels | `bool` | `false` | no |
 | app\_apdex\_score\_runbook\_url | Runbook URL associated to the APP Apdex Score alert condition | `string` | `""` | no |
 | app\_apdex\_score\_t\_threshold | APP Apdex Score T threshold | `number` | `0.5` | no |
 | app\_apdex\_score\_threshold\_critical | APP Apdex Score critical threshold | `number` | `0.7` | no |
@@ -62,9 +74,7 @@ module "newrelic_alerts" {
 | app\_apdex\_score\_threshold\_warning | APP Apdex Score warning threshold | `number` | `0.85` | no |
 | app\_apdex\_score\_violation\_time\_limit | APP Apdex Score violation time limit | `string` | `"one_hour"` | no |
 | appname\_like | Query match appname | `string` | `""` | no |
-| bh\_alert\_channel\_ids | BH alert channels IDs | `list` | `[]` | no |
 | environment | Application environment | `string` | n/a | yes |
-| nbh\_alert\_channel\_ids | NBH alert channels IDs | `list` | `[]` | no |
 | policy\_name | Alert policy name | `string` | n/a | yes |
 | prefixes | Prefixes list to prepend between brackets on every monitors names before environment | `list` | `[]` | no |
 
@@ -72,10 +82,7 @@ module "newrelic_alerts" {
 
 | Name | Description |
 |------|-------------|
-| app\_apdex\_score\_bh\_alert | business hours app apdex score alert |
-| app\_apdex\_score\_nbh\_alert\_critical | business hours app apdex score critical alert |
-| app\_apdex\_score\_nbh\_alert\_warning | business hours app apdex score warning alert |
+| alert\_policy | alert policy |
+| app\_apdex\_score\_alert | app apdex score alert |
 | appname\_like | n/a |
-| bh\_alert\_policy | business hours alert policy |
-| nbh\_alert\_policy | non business hours alert policy |
 

--- a/modules/apm/README.md
+++ b/modules/apm/README.md
@@ -9,10 +9,32 @@ provider "newrelic" {
   region        = "US"  # or EU
 }
 
+resource "newrelic_alert_channel" "pagerduty_bh" {
+  name = "PagerDuty BH"
+  type = "pagerduty"
+
+  config {
+    service_key = "xxx"
+  }
+}
+
+resource "newrelic_alert_channel" "pagerduty_nbh" {
+  name = "PagerDuty NBH"
+  type = "pagerduty"
+
+  config {
+    service_key = "xxx"
+  }
+}
+
 module "newrelic_alerts" {
   source      = "github.com/claranet/terraform-newrelic-alerts//modules/apm"
   environment = "production"
   policy_name = "APM anomalies detected"
+
+  bh_alert_channel_ids               = [newrelic_alert_channel.pagerduty_bh.id]
+  nbh_alert_channel_ids              = [newrelic_alert_channel.pagerduty_nbh.id]
+  app_apdex_score_nbh_alerts_enabled = true
 }
 ```
 
@@ -31,6 +53,7 @@ module "newrelic_alerts" {
 | app\_apdex\_score\_enabled | Flag to enable APP Apdex Score alert condition | `bool` | `true` | no |
 | app\_apdex\_score\_evaluation\_offset | APP Apdex Score evaluation offset | `number` | `3` | no |
 | app\_apdex\_score\_message | Custom message for the APP Apdex Score alert condition | `string` | `"Apdex is low"` | no |
+| app\_apdex\_score\_nbh\_alerts\_enabled | Flag to enable APP Apdex Score critals alerts on NBH channels | `bool` | `false` | no |
 | app\_apdex\_score\_runbook\_url | Runbook URL associated to the APP Apdex Score alert condition | `string` | `""` | no |
 | app\_apdex\_score\_t\_threshold | APP Apdex Score T threshold | `number` | `0.5` | no |
 | app\_apdex\_score\_threshold\_critical | APP Apdex Score critical threshold | `number` | `0.7` | no |
@@ -39,7 +62,9 @@ module "newrelic_alerts" {
 | app\_apdex\_score\_threshold\_warning | APP Apdex Score warning threshold | `number` | `0.85` | no |
 | app\_apdex\_score\_violation\_time\_limit | APP Apdex Score violation time limit | `string` | `"one_hour"` | no |
 | appname\_like | Query match appname | `string` | `""` | no |
+| bh\_alert\_channel\_ids | BH alert channels IDs | `list` | `[]` | no |
 | environment | Application environment | `string` | n/a | yes |
+| nbh\_alert\_channel\_ids | NBH alert channels IDs | `list` | `[]` | no |
 | policy\_name | Alert policy name | `string` | n/a | yes |
 | prefixes | Prefixes list to prepend between brackets on every monitors names before environment | `list` | `[]` | no |
 
@@ -47,7 +72,10 @@ module "newrelic_alerts" {
 
 | Name | Description |
 |------|-------------|
-| app\_apdex\_score\_alert | app apdex score alert |
+| app\_apdex\_score\_bh\_alert | business hours app apdex score alert |
+| app\_apdex\_score\_nbh\_alert\_critical | business hours app apdex score critical alert |
+| app\_apdex\_score\_nbh\_alert\_warning | business hours app apdex score warning alert |
 | appname\_like | n/a |
-| main\_alert\_policy | main alert policy |
+| bh\_alert\_policy | business hours alert policy |
+| nbh\_alert\_policy | non business hours alert policy |
 

--- a/modules/apm/main.tf
+++ b/modules/apm/main.tf
@@ -1,15 +1,19 @@
-resource "newrelic_alert_policy" "main_policy" {
-  name = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] ${var.policy_name}"
+#
+# Business hours alert policy
+#
+
+resource "newrelic_alert_policy" "bh_policy" {
+  name = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] ${var.policy_name} (BH)"
 }
 
-resource "newrelic_nrql_alert_condition" "app_apdex_score_alert" {
-  count       = var.app_apdex_score_enabled == true ? 1 : 0
+resource "newrelic_nrql_alert_condition" "app_apdex_score_bh_alert" {
+  count       = var.app_apdex_score_enabled && ! var.app_apdex_score_nbh_alerts_enabled ? 1 : 0
   name        = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] ${var.app_apdex_score_message}"
   description = var.app_apdex_score_message
   runbook_url = var.app_apdex_score_runbook_url
 
   type                 = "static"
-  policy_id            = newrelic_alert_policy.main_policy.id
+  policy_id            = newrelic_alert_policy.bh_policy.id
   violation_time_limit = var.app_apdex_score_violation_time_limit
   value_function       = "single_value"
   aggregation_window   = var.app_apdex_score_aggregation_window
@@ -36,3 +40,77 @@ EOQ
   }
 }
 
+resource "newrelic_nrql_alert_condition" "app_apdex_score_nbh_alert_warning" {
+  count       = var.app_apdex_score_enabled && var.app_apdex_score_nbh_alerts_enabled ? 1 : 0
+  name        = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] ${var.app_apdex_score_message} (warning)"
+  description = var.app_apdex_score_message
+  runbook_url = var.app_apdex_score_runbook_url
+
+  type                 = "static"
+  policy_id            = newrelic_alert_policy.bh_policy.id
+  violation_time_limit = var.app_apdex_score_violation_time_limit
+  value_function       = "single_value"
+  aggregation_window   = var.app_apdex_score_aggregation_window
+
+  nrql {
+    query             = <<-EOQ
+      SELECT apdex(duration, t:${var.app_apdex_score_t_threshold}) FROM Transaction WHERE appName like '${local.appname_like}'
+EOQ
+    evaluation_offset = var.app_apdex_score_evaluation_offset
+  }
+
+  critical {
+    operator              = "below"
+    threshold             = var.app_apdex_score_threshold_warning
+    threshold_duration    = var.app_apdex_score_threshold_duration_warning
+    threshold_occurrences = "ALL"
+  }
+}
+
+resource "newrelic_alert_policy_channel" "app_apdex_bh_alert_channels" {
+  count       = var.app_apdex_score_enabled ? 1 : 0
+  policy_id   = newrelic_alert_policy.bh_policy.id
+  channel_ids = var.bh_alert_channel_ids
+}
+
+#
+# Non-business hours alert policy
+#
+
+resource "newrelic_alert_policy" "nbh_policy" {
+  count = var.app_apdex_score_nbh_alerts_enabled ? 1 : 0
+  name  = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] ${var.policy_name} (NBH)"
+}
+
+resource "newrelic_nrql_alert_condition" "app_apdex_score_nbh_alert_critical" {
+  count       = var.app_apdex_score_enabled && var.app_apdex_score_nbh_alerts_enabled ? 1 : 0
+  name        = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] ${var.app_apdex_score_message} (critical)"
+  description = var.app_apdex_score_message
+  runbook_url = var.app_apdex_score_runbook_url
+
+  type                 = "static"
+  policy_id            = newrelic_alert_policy.nbh_policy[0].id
+  violation_time_limit = var.app_apdex_score_violation_time_limit
+  value_function       = "single_value"
+  aggregation_window   = var.app_apdex_score_aggregation_window
+
+  nrql {
+    query             = <<-EOQ
+      SELECT apdex(duration, t:${var.app_apdex_score_t_threshold}) FROM Transaction WHERE appName like '${local.appname_like}'
+EOQ
+    evaluation_offset = var.app_apdex_score_evaluation_offset
+  }
+
+  critical {
+    operator              = "below"
+    threshold             = var.app_apdex_score_threshold_critical
+    threshold_duration    = var.app_apdex_score_threshold_duration_critical
+    threshold_occurrences = "ALL"
+  }
+}
+
+resource "newrelic_alert_policy_channel" "app_apdex_nbh_alert_channels" {
+  count       = var.app_apdex_score_enabled && var.app_apdex_score_nbh_alerts_enabled ? 1 : 0
+  policy_id   = newrelic_alert_policy.nbh_policy[0].id
+  channel_ids = var.nbh_alert_channel_ids
+}

--- a/modules/apm/main.tf
+++ b/modules/apm/main.tf
@@ -1,19 +1,20 @@
-#
-# Business hours alert policy
-#
-
-resource "newrelic_alert_policy" "bh_policy" {
-  name = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] ${var.policy_name} (BH)"
+resource "newrelic_alert_policy" "main_policy" {
+  name = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] ${var.policy_name}"
 }
 
-resource "newrelic_nrql_alert_condition" "app_apdex_score_bh_alert" {
-  count       = var.app_apdex_score_enabled && ! var.app_apdex_score_nbh_alerts_enabled ? 1 : 0
+resource "newrelic_alert_policy_channel" "main_policy_alert_channels" {
+  policy_id   = newrelic_alert_policy.main_policy.id
+  channel_ids = var.alert_channel_ids
+}
+
+resource "newrelic_nrql_alert_condition" "app_apdex_score_alert" {
+  count       = var.app_apdex_score_enabled ? 1 : 0
   name        = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] ${var.app_apdex_score_message}"
   description = var.app_apdex_score_message
   runbook_url = var.app_apdex_score_runbook_url
 
   type                 = "static"
-  policy_id            = newrelic_alert_policy.bh_policy.id
+  policy_id            = newrelic_alert_policy.main_policy.id
   violation_time_limit = var.app_apdex_score_violation_time_limit
   value_function       = "single_value"
   aggregation_window   = var.app_apdex_score_aggregation_window
@@ -38,79 +39,4 @@ EOQ
     threshold_duration    = var.app_apdex_score_threshold_duration_warning
     threshold_occurrences = "ALL"
   }
-}
-
-resource "newrelic_nrql_alert_condition" "app_apdex_score_nbh_alert_warning" {
-  count       = var.app_apdex_score_enabled && var.app_apdex_score_nbh_alerts_enabled ? 1 : 0
-  name        = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] ${var.app_apdex_score_message} (warning)"
-  description = var.app_apdex_score_message
-  runbook_url = var.app_apdex_score_runbook_url
-
-  type                 = "static"
-  policy_id            = newrelic_alert_policy.bh_policy.id
-  violation_time_limit = var.app_apdex_score_violation_time_limit
-  value_function       = "single_value"
-  aggregation_window   = var.app_apdex_score_aggregation_window
-
-  nrql {
-    query             = <<-EOQ
-      SELECT apdex(duration, t:${var.app_apdex_score_t_threshold}) FROM Transaction WHERE appName like '${local.appname_like}'
-EOQ
-    evaluation_offset = var.app_apdex_score_evaluation_offset
-  }
-
-  critical {
-    operator              = "below"
-    threshold             = var.app_apdex_score_threshold_warning
-    threshold_duration    = var.app_apdex_score_threshold_duration_warning
-    threshold_occurrences = "ALL"
-  }
-}
-
-resource "newrelic_alert_policy_channel" "app_apdex_bh_alert_channels" {
-  count       = var.app_apdex_score_enabled ? 1 : 0
-  policy_id   = newrelic_alert_policy.bh_policy.id
-  channel_ids = var.bh_alert_channel_ids
-}
-
-#
-# Non-business hours alert policy
-#
-
-resource "newrelic_alert_policy" "nbh_policy" {
-  count = var.app_apdex_score_nbh_alerts_enabled ? 1 : 0
-  name  = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] ${var.policy_name} (NBH)"
-}
-
-resource "newrelic_nrql_alert_condition" "app_apdex_score_nbh_alert_critical" {
-  count       = var.app_apdex_score_enabled && var.app_apdex_score_nbh_alerts_enabled ? 1 : 0
-  name        = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] ${var.app_apdex_score_message} (critical)"
-  description = var.app_apdex_score_message
-  runbook_url = var.app_apdex_score_runbook_url
-
-  type                 = "static"
-  policy_id            = newrelic_alert_policy.nbh_policy[0].id
-  violation_time_limit = var.app_apdex_score_violation_time_limit
-  value_function       = "single_value"
-  aggregation_window   = var.app_apdex_score_aggregation_window
-
-  nrql {
-    query             = <<-EOQ
-      SELECT apdex(duration, t:${var.app_apdex_score_t_threshold}) FROM Transaction WHERE appName like '${local.appname_like}'
-EOQ
-    evaluation_offset = var.app_apdex_score_evaluation_offset
-  }
-
-  critical {
-    operator              = "below"
-    threshold             = var.app_apdex_score_threshold_critical
-    threshold_duration    = var.app_apdex_score_threshold_duration_critical
-    threshold_occurrences = "ALL"
-  }
-}
-
-resource "newrelic_alert_policy_channel" "app_apdex_nbh_alert_channels" {
-  count       = var.app_apdex_score_enabled && var.app_apdex_score_nbh_alerts_enabled ? 1 : 0
-  policy_id   = newrelic_alert_policy.nbh_policy[0].id
-  channel_ids = var.nbh_alert_channel_ids
 }

--- a/modules/apm/outputs.tf
+++ b/modules/apm/outputs.tf
@@ -2,12 +2,30 @@ output "appname_like" {
   value = local.appname_like
 }
 
-output "main_alert_policy" {
-  description = "main alert policy"
-  value       = newrelic_alert_policy.main_policy
+output "bh_alert_policy" {
+  description = "business hours alert policy"
+  value       = newrelic_alert_policy.bh_policy
 }
 
-output "app_apdex_score_alert" {
-  description = "app apdex score alert"
-  value       = newrelic_nrql_alert_condition.app_apdex_score_alert.*
+output "nbh_alert_policy" {
+  description = "non business hours alert policy"
+  value       = newrelic_alert_policy.nbh_policy
+}
+
+output "app_apdex_score_bh_alert" {
+  #count       = var.app_apdex_score_enabled && ! var.app_apdex_score_nbh_alerts_enabled ? 1 : 0
+  description = "business hours app apdex score alert"
+  value       = newrelic_nrql_alert_condition.app_apdex_score_bh_alert.*
+}
+
+output "app_apdex_score_nbh_alert_warning" {
+  #count       = var.app_apdex_score_enabled && var.app_apdex_score_nbh_alerts_enabled ? 1 : 0
+  description = "business hours app apdex score warning alert"
+  value       = newrelic_nrql_alert_condition.app_apdex_score_nbh_alert_warning.*
+}
+
+output "app_apdex_score_nbh_alert_critical" {
+  #count       = var.app_apdex_score_enabled && var.app_apdex_score_nbh_alerts_enabled ? 1 : 0
+  description = "business hours app apdex score critical alert"
+  value       = newrelic_nrql_alert_condition.app_apdex_score_nbh_alert_critical.*
 }

--- a/modules/apm/outputs.tf
+++ b/modules/apm/outputs.tf
@@ -2,30 +2,12 @@ output "appname_like" {
   value = local.appname_like
 }
 
-output "bh_alert_policy" {
-  description = "business hours alert policy"
-  value       = newrelic_alert_policy.bh_policy
+output "alert_policy" {
+  description = "alert policy"
+  value       = newrelic_alert_policy.main_policy
 }
 
-output "nbh_alert_policy" {
-  description = "non business hours alert policy"
-  value       = newrelic_alert_policy.nbh_policy
-}
-
-output "app_apdex_score_bh_alert" {
-  #count       = var.app_apdex_score_enabled && ! var.app_apdex_score_nbh_alerts_enabled ? 1 : 0
-  description = "business hours app apdex score alert"
-  value       = newrelic_nrql_alert_condition.app_apdex_score_bh_alert.*
-}
-
-output "app_apdex_score_nbh_alert_warning" {
-  #count       = var.app_apdex_score_enabled && var.app_apdex_score_nbh_alerts_enabled ? 1 : 0
-  description = "business hours app apdex score warning alert"
-  value       = newrelic_nrql_alert_condition.app_apdex_score_nbh_alert_warning.*
-}
-
-output "app_apdex_score_nbh_alert_critical" {
-  #count       = var.app_apdex_score_enabled && var.app_apdex_score_nbh_alerts_enabled ? 1 : 0
-  description = "business hours app apdex score critical alert"
-  value       = newrelic_nrql_alert_condition.app_apdex_score_nbh_alert_critical.*
+output "app_apdex_score_alert" {
+  description = "app apdex score alert"
+  value       = newrelic_nrql_alert_condition.app_apdex_score_alert.*
 }

--- a/modules/apm/variables.tf
+++ b/modules/apm/variables.tf
@@ -23,9 +23,22 @@ variable "prefixes" {
   default     = []
 }
 
+variable "bh_alert_channel_ids" {
+  description = "BH alert channels IDs"
+  type        = list
+  default     = []
+}
+
+variable "nbh_alert_channel_ids" {
+  description = "NBH alert channels IDs"
+  type        = list
+  default     = []
+}
+
 #
 # APP Apdex Score
 #
+
 variable "app_apdex_score_aggregation_window" {
   description = "APP Apdex Score aggregation window"
   type        = number
@@ -36,6 +49,12 @@ variable "app_apdex_score_enabled" {
   description = "Flag to enable APP Apdex Score alert condition"
   type        = bool
   default     = true
+}
+
+variable "app_apdex_score_nbh_alerts_enabled" {
+  description = "Flag to enable APP Apdex Score critals alerts on NBH channels"
+  type        = bool
+  default     = false
 }
 
 variable "app_apdex_score_evaluation_offset" {

--- a/modules/apm/variables.tf
+++ b/modules/apm/variables.tf
@@ -23,14 +23,8 @@ variable "prefixes" {
   default     = []
 }
 
-variable "bh_alert_channel_ids" {
-  description = "BH alert channels IDs"
-  type        = list
-  default     = []
-}
-
-variable "nbh_alert_channel_ids" {
-  description = "NBH alert channels IDs"
+variable "alert_channel_ids" {
+  description = "Alert channels IDs"
   type        = list
   default     = []
 }
@@ -49,12 +43,6 @@ variable "app_apdex_score_enabled" {
   description = "Flag to enable APP Apdex Score alert condition"
   type        = bool
   default     = true
-}
-
-variable "app_apdex_score_nbh_alerts_enabled" {
-  description = "Flag to enable APP Apdex Score critals alerts on NBH channels"
-  type        = bool
-  default     = false
 }
 
 variable "app_apdex_score_evaluation_offset" {


### PR DESCRIPTION
Adding support for PagerDuty (or other channel types) with separated alert policies for BH and NBH alerts if enabled.