### PR TITLE
fix: remove warning on deprecated field violation_time_limit

### DIFF
--- a/modules/apm/README.md
+++ b/modules/apm/README.md
@@ -72,7 +72,7 @@ module "newrelic_alerts_webfront_nbh" {
 | app\_apdex\_score\_threshold\_duration\_critical | APP Apdex Score critical threshold duration | `number` | `300` | no |
 | app\_apdex\_score\_threshold\_duration\_warning | APP Apdex Score warning threshold duration | `number` | `600` | no |
 | app\_apdex\_score\_threshold\_warning | APP Apdex Score warning threshold | `number` | `0.85` | no |
-| app\_apdex\_score\_violation\_time\_limit | APP Apdex Score violation time limit | `string` | `"one_hour"` | no |
+| app\_apdex\_score\_violation\_time\_limit_seconds | APP Apdex Score violation time limit seconds | `number` | `3600` | no |
 | appname\_like | Query match appname | `string` | `""` | no |
 | environment | Application environment | `string` | n/a | yes |
 | policy\_name | Alert policy name | `string` | n/a | yes |

--- a/modules/apm/main.tf
+++ b/modules/apm/main.tf
@@ -13,11 +13,11 @@ resource "newrelic_nrql_alert_condition" "app_apdex_score_alert" {
   description = var.app_apdex_score_message
   runbook_url = var.app_apdex_score_runbook_url
 
-  type                 = "static"
-  policy_id            = newrelic_alert_policy.main_policy.id
-  violation_time_limit = var.app_apdex_score_violation_time_limit
-  value_function       = "single_value"
-  aggregation_window   = var.app_apdex_score_aggregation_window
+  type                         = "static"
+  policy_id                    = newrelic_alert_policy.main_policy.id
+  violation_time_limit_seconds = var.app_apdex_score_violation_time_limit_seconds
+  value_function               = "single_value"
+  aggregation_window           = var.app_apdex_score_aggregation_window
 
   nrql {
     query             = <<-EOQ

--- a/modules/apm/variables.tf
+++ b/modules/apm/variables.tf
@@ -93,8 +93,8 @@ variable "app_apdex_score_threshold_warning" {
   default     = 0.85
 }
 
-variable "app_apdex_score_violation_time_limit" {
-  description = "APP Apdex Score violation time limit"
-  type        = string
-  default     = "one_hour"
+variable "app_apdex_score_violation_time_limit_seconds" {
+  description = "APP Apdex Score violation time limit seconds"
+  type        = number
+  default     = 3600
 }


### PR DESCRIPTION
Since the version 2.14 of newrelic provider, the parameter `violation_time_limit` is deprecated.

This PR fixes the warning and use the parameter `violation_time_limit_seconds` as mentioned in the documentation.

