### PR TITLE
Replace deprecated evaluation_offset parameter

### DIFF
--- a/modules/apm/README.md
+++ b/modules/apm/README.md
@@ -61,10 +61,10 @@ module "newrelic_alerts_webfront_nbh" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| alert\_channel\_ids | Alert channels IDs | `list` | `[]` | no |
+| alert\_channel\_ids | Alert channels IDs | `list(string)` | `[]` | no |
 | app\_apdex\_score\_aggregation\_window | APP Apdex Score aggregation window | `number` | `60` | no |
 | app\_apdex\_score\_enabled | Flag to enable APP Apdex Score alert condition | `bool` | `true` | no |
-| app\_apdex\_score\_evaluation\_offset | APP Apdex Score evaluation offset | `number` | `3` | no |
+| app\_apdex\_score\_evaluation\_delay\_seconds | APP Apdex Score evaluation delay in seconds | `number` | `180` | no |
 | app\_apdex\_score\_message | Custom message for the APP Apdex Score alert condition | `string` | `"Apdex is low"` | no |
 | app\_apdex\_score\_runbook\_url | Runbook URL associated to the APP Apdex Score alert condition | `string` | `""` | no |
 | app\_apdex\_score\_t\_threshold | APP Apdex Score T threshold | `number` | `0.5` | no |
@@ -72,11 +72,11 @@ module "newrelic_alerts_webfront_nbh" {
 | app\_apdex\_score\_threshold\_duration\_critical | APP Apdex Score critical threshold duration | `number` | `300` | no |
 | app\_apdex\_score\_threshold\_duration\_warning | APP Apdex Score warning threshold duration | `number` | `600` | no |
 | app\_apdex\_score\_threshold\_warning | APP Apdex Score warning threshold | `number` | `0.85` | no |
-| app\_apdex\_score\_violation\_time\_limit_seconds | APP Apdex Score violation time limit seconds | `number` | `3600` | no |
+| app\_apdex\_score\_violation\_time\_limit\_seconds | APP Apdex Score violation time limit seconds | `number` | `3600` | no |
 | appname\_like | Query match appname | `string` | `""` | no |
 | environment | Application environment | `string` | n/a | yes |
 | policy\_name | Alert policy name | `string` | n/a | yes |
-| prefixes | Prefixes list to prepend between brackets on every monitors names before environment | `list` | `[]` | no |
+| prefixes | Prefixes list to prepend between brackets on every monitors names before environment | `list(string)` | `[]` | no |
 
 ## Outputs
 
@@ -85,4 +85,3 @@ module "newrelic_alerts_webfront_nbh" {
 | alert\_policy | alert policy |
 | app\_apdex\_score\_alert | app apdex score alert |
 | appname\_like | n/a |
-

--- a/modules/apm/main.tf
+++ b/modules/apm/main.tf
@@ -16,14 +16,14 @@ resource "newrelic_nrql_alert_condition" "app_apdex_score_alert" {
   type                         = "static"
   policy_id                    = newrelic_alert_policy.main_policy.id
   violation_time_limit_seconds = var.app_apdex_score_violation_time_limit_seconds
-  value_function               = "single_value"
   aggregation_window           = var.app_apdex_score_aggregation_window
+  aggregation_method           = "event_flow"
+  aggregation_delay            = var.app_apdex_score_evaluation_delay_seconds
 
   nrql {
-    query             = <<-EOQ
+    query = <<-EOQ
       SELECT apdex(duration, t:${var.app_apdex_score_t_threshold}) FROM Transaction WHERE appName like '${local.appname_like}'
 EOQ
-    evaluation_offset = var.app_apdex_score_evaluation_offset
   }
 
   critical {

--- a/modules/apm/variables.tf
+++ b/modules/apm/variables.tf
@@ -19,13 +19,13 @@ variable "policy_name" {
 
 variable "prefixes" {
   description = "Prefixes list to prepend between brackets on every monitors names before environment"
-  type        = list
+  type        = list(string)
   default     = []
 }
 
 variable "alert_channel_ids" {
   description = "Alert channels IDs"
-  type        = list
+  type        = list(string)
   default     = []
 }
 
@@ -45,10 +45,10 @@ variable "app_apdex_score_enabled" {
   default     = true
 }
 
-variable "app_apdex_score_evaluation_offset" {
-  description = "APP Apdex Score evaluation offset"
+variable "app_apdex_score_evaluation_delay_seconds" {
+  description = "APP Apdex Score evaluation delay in seconds"
   type        = number
-  default     = 3
+  default     = 180
 }
 
 variable "app_apdex_score_message" {


### PR DESCRIPTION
Replace deprecated parameters in NewRelic provider v2, see https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/nrql_alert_condition

cc @gbloquel 